### PR TITLE
SSR vs Electromechanical relay clarification + blue board picture update

### DIFF
--- a/docs/stm32-upgrade-pack/blackpill.md
+++ b/docs/stm32-upgrade-pack/blackpill.md
@@ -66,7 +66,7 @@ The nano expansion board you already have mirrors the nano pin locations but not
 |           	    |   3V3               	|   PA10         		    |   PB0                 |   D11                     |   HX711_sck_1                 |
 |   		        |   REF		            |   PA11  		            |   PA7                 |   D10                     |                               |
 |                   |   A0                  |   PA12                    |   PA6                 |   D9                      |   thermoCS                    |
-|   relayPin        |   A1                  |   PA15                    |   PA5                 |   D8                      |   thermoCLK                   |
+|   relayPin*       |   A1                  |   PA15                    |   PA5                 |   D8                      |   thermoCLK                   |
 |                   |   A2                  |   PB3                     |   PA4                 |   D7                      |                               |
 |   thermoDO        |   A3                  |   PB4                     |   PA3                 |   D6                      |   TX                          |
 |                   |   A4                  |   PB5                     |   PA2                 |   D5                      |   RX                          |
@@ -75,8 +75,11 @@ The nano expansion board you already have mirrors the nano pin locations but not
 |   HX711_dout_1    |   A7                  |   PB8                     |   R                   |   D2                      |                               |
 |   HX711_dout_2    |   5V                  |   PB9                     |   C15                 |   GND                     |   steamPin                    |
 |   5V              |   RST                 |   5V                      |   C14                 |   RST                     |   brewPin                     |
-|   GND             |   GND                 |   GND                     |   C13                 |   RXO                     |   valvePin                    |
+|   GND             |   GND                 |   GND                     |   C13                 |   RXO                     |   valvePin^                   |
 |                   |   VIN                 |   3V3                     |   VB                  |   TXT                     |                               |      
+
+<sup>*</sup> this is the SSR controlling the heater  
+<sup>^</sup> this is the 5V relay that replaces the optocoupler
 
 ## SOFTWARE INSTALLATION
 
@@ -93,7 +96,7 @@ Consider buying an ST-Link v2 to more easily upgrade the firmware onto the Black
 
 ![ST-Link](https://user-images.githubusercontent.com/80347096/191400915-6ed2a991-5f0c-4d2a-b52d-aad29978c0d1.jpg)
 
-## RELAY INSTALLATION
+## 5V RELAY INSTALLATION
 
 Installing the relay allows the Gaggiuino to perform advanced functions (in conjunction with other necessary hardware): 
 

--- a/docs/stm32-upgrade-pack/blackpill.md
+++ b/docs/stm32-upgrade-pack/blackpill.md
@@ -26,8 +26,8 @@ Always refer to the official Gaggiuino BOM on the Github project page for the mo
 
 ### Expansion Board Compatibility 
  
-Ensure your expansion board circuitry looks like the bottom left (green) and not the bottom right (blue). The bottom right (blue) will not work correctly with the standard pindefs (it will not trigger the relay to heat up the boiler), so it is advised for most people to purchase the board from the BOM that looks like the green expansion board. 
-![Expansion Boards](https://user-images.githubusercontent.com/80347096/191157625-4ef4f8d1-0811-4800-b28f-b26ab0f22a12.png)
+Ensure your expansion board circuitry looks like the bottom left (green) and not the bottom right (blue). The bottom right (blue) will not work correctly with the standard pindefs (it will not trigger the relay to heat up the boiler - the two circled pins in yellow are marked `GND` on the reverse and are both connected to the groundplane and each other), so it is advised for most people to purchase the board from the BOM that looks like the green expansion board.  
+![Expansion Boards](https://user-images.githubusercontent.com/2452284/204672901-ac1a89d9-cbf2-4367-9196-e1a74fbce7dd.png)
 
 ### Important Considerations Before You Begin The Next Section
 


### PR DESCRIPTION
First commit is a minor diagram update highlighting _exactly_ the problem with the blue board is incase someone get a red or other coloured board and isn't sure - hopefully this makes it super clear what to look out for.

Second is on the STM32 page, the pin is called `relayPin` matching the pindefs, but the text talks about 'relay' as in the 5v relay. Coming from reading the GC/GCP page this tripped me up initially, so figured the disambiguation might be worthwhile.