### PR TITLE
Edit sch res

### DIFF
--- a/docs/gc/gaggia-classic.md
+++ b/docs/gc/gaggia-classic.md
@@ -5,8 +5,8 @@
 # SCHEMATICS & DIAGRAMS
 **Schematics:**
 * [GAGGIA Classic **Nano** HV wiring](https://user-images.githubusercontent.com/42692077/161397293-82df427a-2ac2-4226-bdc6-fa831a962265.png)
-* [STM32 Comp GC **STM32-Blackpill** HV wiring](https://user-images.githubusercontent.com/53577819/220784848-ab1fe9f1-92cc-40b4-a1c7-7200ab9a2b87.JPG)
-* [STM32 Comp GC **STM32-Blackpill** LV wiring](https://user-images.githubusercontent.com/53577819/220784856-c1b5f073-5c0b-470e-b47e-c78eda7099ea.JPG)
+* [GAGGIA Classic **STM32-Blackpill** HV wiring](https://user-images.githubusercontent.com/53577819/220784848-ab1fe9f1-92cc-40b4-a1c7-7200ab9a2b87.JPG)
+* [GAGGIA Classic **STM32-Blackpill** LV wiring](https://user-images.githubusercontent.com/53577819/220784856-c1b5f073-5c0b-470e-b47e-c78eda7099ea.JPG)
 
 **Diagrams:**
 * [GAGGIA Classic **Nano** LV wiring](https://user-images.githubusercontent.com/42692077/160548957-88c93198-6d81-4081-8db6-552b6f6c5281.png)

--- a/docs/gc/gaggia-classic.md
+++ b/docs/gc/gaggia-classic.md
@@ -5,8 +5,8 @@
 # SCHEMATICS & DIAGRAMS
 **Schematics:**
 * [GAGGIA Classic **Nano** HV wiring](https://user-images.githubusercontent.com/42692077/161397293-82df427a-2ac2-4226-bdc6-fa831a962265.png)
-* [GAGGIA Classic **STM32-Blackpill** HV wiring](https://user-images.githubusercontent.com/117388662/204613299-8921379c-7bc0-4cf2-ae9f-0b7c7dd12654.JPG)
-* [GAGGIA Classic **STM32-Blackpill** LV wiring](https://user-images.githubusercontent.com/117388662/204613314-01b55b08-4702-4de5-8a25-f4e9dd1442b6.JPG)
+* [STM32 Comp GC **STM32-Blackpill** HV wiring](https://user-images.githubusercontent.com/53577819/220784848-ab1fe9f1-92cc-40b4-a1c7-7200ab9a2b87.JPG)
+* [STM32 Comp GC **STM32-Blackpill** LV wiring](https://user-images.githubusercontent.com/53577819/220784856-c1b5f073-5c0b-470e-b47e-c78eda7099ea.JPG)
 
 **Diagrams:**
 * [GAGGIA Classic **Nano** LV wiring](https://user-images.githubusercontent.com/42692077/160548957-88c93198-6d81-4081-8db6-552b6f6c5281.png)

--- a/docs/guides/lego-component-build-guide.md
+++ b/docs/guides/lego-component-build-guide.md
@@ -1,5 +1,5 @@
 This is a quick guide on how to best piece together the Gaggiuino mod into the 3D printed housing.
-Lots of images are provided to give you a sense of what a completed lego build should look like in the box.
+Lots of images are provided to give you a sense of what a completed STM32 component (Lego) build should look like in the box.
 
 # Preparation 
 It is recommended to remove pins on the dimmer and thermocouple interface boards for the smallest, best connection. If you’d prefer to not do this in later steps you can solder wires to the pins and heat shrink over them.
@@ -69,9 +69,11 @@ Note: you can use strip board for power distribution (cut for 6x5 usable points)
 <img width="547" alt="image" src="https://user-images.githubusercontent.com/53577819/211652610-4b63d97b-90fd-43b1-b37f-a71ad0523008.png">
 
 # Component Wiring 
-The next steps describe the process of wiring the components together. You can do the power wiring first, then follow it up with the component signal wiring, but it can be done in whatever order you like. Trust the schematic if you’re confused on a step or there appears to be a difference between an image and the schematic. You can use 22AWG wires unless otherwise noted; see the schematic for permissible wire gauges.
+The next steps describe the process of wiring the components together. You can do the power wiring first, then follow it up with the component signal wiring, but it can be done in whatever order you like. Trust the schematic if you’re confused on a step or there appears to be a difference between an image and the schematic. You can use 22-26AWG wires unless otherwise noted; see the schematic for permissible wire gauges.
 
-<img width="649" alt="image" src="https://user-images.githubusercontent.com/53577819/211652678-d2f92acd-9b50-41ec-885b-a6c1a043e969.png">
+<img width="854" alt="image" src="https://user-images.githubusercontent.com/117388662/230696068-e49df2fa-c3b6-49c2-80ff-629b80780938.png">
+
+[STM32 Internal Comp Housing Schematic](https://user-images.githubusercontent.com/117388662/230696068-e49df2fa-c3b6-49c2-80ff-629b80780938.png)
 
 ## Power wiring 
 If using a strip board it is recommended to use an arrangement like this with two rows of 5V and two rows of 5V GND (0 VDC). 

--- a/docs/stm32-upgrade-pack/blackpill.md
+++ b/docs/stm32-upgrade-pack/blackpill.md
@@ -114,4 +114,4 @@ The nano and blackpill/stm32 have different pin setups on their respective board
 * [STM32 Comp GCP LV](https://user-images.githubusercontent.com/53577819/220784877-279de614-afe9-4bcf-bf27-a6e25edb06bc.JPG)
 
 **Internal component config**
-* [STM32 Internal Comp Housing Schematic](https://user-images.githubusercontent.com/117388662/209090732-28ab3147-38c6-4571-8668-803e8d9155e9.png)
+* [STM32 Internal Comp Housing Schematic](https://user-images.githubusercontent.com/117388662/230696068-e49df2fa-c3b6-49c2-80ff-629b80780938.png)


### PR DESCRIPTION
Simple edits - 2 schematic images got out of sync between pages, and a low-res file was the source for some images. Fixed both. No changes to the schematic contents.