### PR TITLE
Update/independent relay dimmer

### DIFF
--- a/docs/_sidebar.md
+++ b/docs/_sidebar.md
@@ -10,5 +10,6 @@
 * - [Gaggia Classic Pro](gcp/gaggia-classic-pro-new-classic.md)
 * - Upgrades
     * [Lego AIO Housing](guides/lego-component-build-guide.md)
+    * [Lego Independent Relay and Dimmer](guides/lego-independent-relay-dimmer.md)
     * [STM32 UPGRADE](stm32-upgrade-pack/blackpill.md)
     * [PCB](pcb/singleboard.md)

--- a/docs/gc/gaggia-classic.md
+++ b/docs/gc/gaggia-classic.md
@@ -3,10 +3,11 @@
 >Following the guide you agree that any damage you induce to your house appliances, yourself, your cat, your friend, or your gold fish will be entirely your fault!
 
 # SCHEMATICS & DIAGRAMS
+
+?> STM32 schematics are on the [STM32 UPGRADE](stm32-upgrade-pack/blackpill.md) page
+
 **Schematics:**
 * [GAGGIA Classic **Nano** HV wiring](https://user-images.githubusercontent.com/42692077/161397293-82df427a-2ac2-4226-bdc6-fa831a962265.png)
-* [GAGGIA Classic **STM32-Blackpill** HV wiring](https://user-images.githubusercontent.com/53577819/220784848-ab1fe9f1-92cc-40b4-a1c7-7200ab9a2b87.JPG)
-* [GAGGIA Classic **STM32-Blackpill** LV wiring](https://user-images.githubusercontent.com/53577819/220784856-c1b5f073-5c0b-470e-b47e-c78eda7099ea.JPG)
 
 **Diagrams:**
 * [GAGGIA Classic **Nano** LV wiring](https://user-images.githubusercontent.com/42692077/160548957-88c93198-6d81-4081-8db6-552b6f6c5281.png)

--- a/docs/gcp/gaggia-classic-pro-new-classic.md
+++ b/docs/gcp/gaggia-classic-pro-new-classic.md
@@ -353,6 +353,8 @@ All going well, feel like an absolute coffee titan each and every time you pull 
 > [!NOTE]
 >**THE SCHEMATIC DRAWINGS HAVE BEEN DRAWN FLIPPED AND UPSIDE DOWN. BLAME GAGGIA.**
 
+?> STM32 schematics are on the [STM32 UPGRADE](stm32-upgrade-pack/blackpill.md) page
+
 **Schematics:**
 * [GAGGIA New Classic 2018/19](https://user-images.githubusercontent.com/53577819/214380779-ec53b99b-2b7c-4781-acdc-90c3879353c0.png)
 * [GAGGIA New Classic 2018/19 **Nano** Wiring](https://user-images.githubusercontent.com/53577819/221353183-6b389c6e-dd53-4594-b504-79460aa15fda.png)

--- a/docs/guides/lego-component-build-guide.md
+++ b/docs/guides/lego-component-build-guide.md
@@ -1,6 +1,8 @@
 This is a quick guide on how to best piece together the Gaggiuino mod into the 3D printed housing.
 Lots of images are provided to give you a sense of what a completed STM32 component (Lego) build should look like in the box.
 
+[comment]: # (needs new pics and updates to better align with the independent relay and dimmer guide, but is OK-ish for now)
+
 # Preparation 
 It is recommended to remove pins on the dimmer and thermocouple interface boards for the smallest, best connection. If you’d prefer to not do this in later steps you can solder wires to the pins and heat shrink over them.
 An easy way to remove header pins is to cut the plastic linkage between each pin with snips, then de-solder the pins individually. Solder wick or a solder sucker can help get the through holes nice and clean.
@@ -69,11 +71,11 @@ Note: you can use strip board for power distribution (cut for 6x5 usable points)
 <img width="547" alt="image" src="https://user-images.githubusercontent.com/53577819/211652610-4b63d97b-90fd-43b1-b37f-a71ad0523008.png">
 
 # Component Wiring 
-The next steps describe the process of wiring the components together. You can do the power wiring first, then follow it up with the component signal wiring, but it can be done in whatever order you like. Trust the schematic if you’re confused on a step or there appears to be a difference between an image and the schematic. You can use 22-26AWG wires unless otherwise noted; see the schematic for permissible wire gauges.
+The next steps describe the process of wiring the components together. You can do the power wiring first, then follow it up with the component signal wiring, but it can be done in whatever order you like. Trust the schematic if you’re confused on a step or there appears to be a difference between an image and the schematic. You can use 22-26AWG wires for LV wiring unless otherwise noted; see the schematic for permissible wire gauges.
 
-<img width="854" alt="image" src="https://user-images.githubusercontent.com/117388662/230696068-e49df2fa-c3b6-49c2-80ff-629b80780938.png">
+<img width="854" alt="image" src="https://user-images.githubusercontent.com/117388662/235083835-fa2b6721-598c-4fca-9ac7-eb23a2aa596b.png">
 
-[STM32 Internal Comp Housing Schematic](https://user-images.githubusercontent.com/117388662/230696068-e49df2fa-c3b6-49c2-80ff-629b80780938.png)
+[STM32 Internal Comp Housing Schematic](https://user-images.githubusercontent.com/117388662/235083835-fa2b6721-598c-4fca-9ac7-eb23a2aa596b.png)
 
 ## Power wiring 
 If using a strip board it is recommended to use an arrangement like this with two rows of 5V and two rows of 5V GND (0 VDC). 
@@ -89,7 +91,7 @@ Measure distance to components in the housing, cut wires to length plus ~1 cm, t
 
 <img width="610" alt="image" src="https://user-images.githubusercontent.com/53577819/211653005-8bffe9c8-1967-461d-a163-9a130534e0d0.png">
 
-Now that power wires have been added I’ll begin adding signal wires per the schematic. Just like with the power wires, measure length in the housing, then remove from housing to solder. A few notes:
+Now that power wires have been added we’ll begin adding signal wires per the schematic. Just like with the power wires, measure length in the housing, then remove from housing to solder. A few notes:
 1. Make sure to route the wires before measuring. There is not enough clearance for wires to go over the Blackpill, they must go around. 
 2. Up to you whether you cut the pressure transducer cable shorter. Option to cut it down to about 12 in / 30 cm for my GC, but you may want it longer depending on your specific machine. 
 
@@ -110,7 +112,7 @@ Wiring the pull-up 5V to A1, A2, and A3 is optional, but easy. Just make sure th
 ## Snubber
 The snubber is not required for operation but should extend the life of the 5v relay and will reduce EMI, allowing you to route wires closer together.
 
-To wire you’ll need to make a pair of jumpers from snubber to relay, with the main wire going out to the solenoid. The wires don’t need to be large, you can use 26AWG for the jumper.
+To wire you’ll need to make a pair of jumpers from snubber to relay, with the main wire going out to the solenoid. Ideal wire size is 22 gauge, per schematic.
 
 <img width="444" alt="image" src="https://user-images.githubusercontent.com/53577819/211653512-822f7705-2acd-4210-b50f-f497e9b402bc.png">
 

--- a/docs/guides/lego-component-build-guide.md
+++ b/docs/guides/lego-component-build-guide.md
@@ -112,7 +112,7 @@ Wiring the pull-up 5V to A1, A2, and A3 is optional, but easy. Just make sure th
 ## Snubber
 The snubber is not required for operation but should extend the life of the 5v relay and will reduce EMI, allowing you to route wires closer together.
 
-To wire you’ll need to make a pair of jumpers from snubber to relay, with the main wire going out to the solenoid. Ideal wire size is 22 gauge, per schematic.
+To wire you’ll need to make a pair of jumpers from snubber to relay, with the main wire going out to the solenoid. Reference schematic for wire gauge.
 
 <img width="444" alt="image" src="https://user-images.githubusercontent.com/53577819/211653512-822f7705-2acd-4210-b50f-f497e9b402bc.png">
 

--- a/docs/guides/lego-independent-relay-dimmer.md
+++ b/docs/guides/lego-independent-relay-dimmer.md
@@ -1,0 +1,59 @@
+This is a guide on how to make the relay (controlling the 3-way valve) and dimmer (controlling the pump) independent on "Lego" (component) builds. 
+Independent control allows proper phase recognition, calibration, and tracking.
+
+# Notes
+*   Pump and relay wire size recommendation is now ≤22 gauge because it is difficult to fit multiple 18 gauge wires into the screw terminals. 
+*   Standard short-circuit protection calculations show that 22 gauge wire is permissible for known breakers 20 amps and under, however, this is smaller than standard. Your safety is your responsibility.
+
+!> Powering your machine through a GFCI/AFCI/RCD device is recommended. 
+
+# Schematics
+
+[comment]: # (really wanted to make this a table but it just didn't agree with me)
+
+## Old
+
+**HV Diagrams**
+* [STM32 Comp GC HV](https://user-images.githubusercontent.com/53577819/220784848-ab1fe9f1-92cc-40b4-a1c7-7200ab9a2b87.JPG)
+* [STM32 Comp GCP HV](https://user-images.githubusercontent.com/53577819/220784874-583bb885-dce0-4fda-a920-4dc289607213.JPG)
+* [STM32 Comp GCP_Eco HV](https://user-images.githubusercontent.com/53577819/220784834-fb1536e3-81cc-47e8-a243-21f6c3e49a7f.JPG)
+
+**LV Diagrams**
+* [STM32 Comp GC LV](https://user-images.githubusercontent.com/53577819/220784856-c1b5f073-5c0b-470e-b47e-c78eda7099ea.JPG)
+* [STM32 Comp GCP LV](https://user-images.githubusercontent.com/53577819/220784877-279de614-afe9-4bcf-bf27-a6e25edb06bc.JPG)
+* [STM32 Comp GCP_Eco LV](https://user-images.githubusercontent.com/53577819/220784865-b52ffb3f-8380-4225-a539-15d44738d2fe.JPG)
+
+**Internal Component Housing**
+* [STM32 Internal Comp Housing Schematic](https://user-images.githubusercontent.com/117388662/230696068-e49df2fa-c3b6-49c2-80ff-629b80780938.png)
+
+## New (Independent Relay and Dimmer)
+
+**HV Diagrams**
+* [STM32 Comp GC HV - IRD](https://user-images.githubusercontent.com/117388662/235083196-739bb6db-7213-4cac-8293-75cbcc81b5ef.JPG)
+* [STM32 Comp GCP HV - IRD](https://user-images.githubusercontent.com/117388662/235083465-80c8cb69-6442-453d-ac2a-821b7da190be.JPG)
+* [STM32 Comp GCP_Eco HV - IRD](https://user-images.githubusercontent.com/117388662/235083687-5615555c-7295-4172-87b0-cbe3a2414cf9.JPG)
+
+**LV Diagrams**
+* [STM32 Comp GC LV - IRD](https://user-images.githubusercontent.com/117388662/235083350-c73974d9-bef9-4eee-9b8b-436c999ba291.JPG)
+* [STM32 Comp GCP LV - IRD](https://user-images.githubusercontent.com/117388662/235083525-713be71f-dfb9-4c73-9d89-b93d0a19b8ed.JPG)
+* [STM32 Comp GCP_Eco LV - IRD](https://user-images.githubusercontent.com/117388662/235083749-03cd7b0b-acbb-43b4-9705-1a42073605d4.JPG)
+
+**Internal Component Housing**
+* [STM32 Internal Comp Housing Schematic - IRD](https://user-images.githubusercontent.com/117388662/235083835-fa2b6721-598c-4fca-9ac7-eb23a2aa596b.png)
+
+# Guide
+1. Disconnect pump source Line that is going to Dimmer L-IN. Tuck away the stock female spade (do not reconnect to the pump) and completely remove the wire that connected it to the Dimmer L-IN in the component housing. 
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077019-95c1681c-e3e7-40f4-bfc9-07b60f433896.JPG">
+
+2. Find the Line wire going from the coffee switch to the Relay and disconnect it (confirm, but if you followed the schematics exactly it should be connected to Relay COM). 
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077658-491bb7ed-818c-4cc8-9082-2a1d7aa85e5f.JPG">
+
+3. Move the disconnected coffee switch Line wire to Dimmer L-IN (where you removed the pump wire). You may also want to swap this for a 22 gauge wire for ease of connecting jumpers in the next step.
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077865-1c85d17f-5c47-4681-a0f0-65bbabf2ec78.JPG">
+
+4. Jumper from Dimmer L-IN to Relay COM, and from Relay COM to the snubber (if present). It is recommended to verify that your changes match the updated schematics. This completes the update.
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235078161-5d425621-2257-48f2-9349-6e662d68b826.JPG">

--- a/docs/guides/lego-independent-relay-dimmer.md
+++ b/docs/guides/lego-independent-relay-dimmer.md
@@ -1,11 +1,31 @@
 This is a guide on how to make the relay (controlling the 3-way valve) and dimmer (controlling the pump) independent on "Lego" (component) builds. 
 Independent control allows proper phase recognition, calibration, and tracking.
 
+> [!Warning]
+> Understanding & utilizing safe electrical practices is critical to your safety and safely completing this project. **Always work with the Gaggia unplugged.** You are performing this project under your own risk and the author of this guide and anyone associated with this project are NOT liable for your actions. 
+
 # Notes
 *   Pump and relay wire size recommendation is now ≤22 gauge because it is difficult to fit multiple 18 gauge wires into the screw terminals. 
 *   Standard short-circuit protection calculations show that 22 gauge wire is permissible for known breakers 20 amps and under, however, this is smaller than standard. Your safety is your responsibility.
 
 !> Powering your machine through a GFCI/AFCI/RCD device is recommended. 
+
+# Guide
+1. Disconnect pump source Line that is going to Dimmer L-IN. Tuck away the stock female spade (do not reconnect to the pump) and completely remove the wire that connected it to the Dimmer L-IN in the component housing. 
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077019-95c1681c-e3e7-40f4-bfc9-07b60f433896.JPG">
+
+2. Find the Line wire going from the coffee switch to the Relay and disconnect it (confirm, but if you followed the schematics exactly it should be connected to Relay COM). 
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077658-491bb7ed-818c-4cc8-9082-2a1d7aa85e5f.JPG">
+
+3. Move the disconnected coffee switch Line wire to Dimmer L-IN (where you removed the pump wire). You may also want to swap this for a 22 gauge wire for ease of connecting jumpers in the next step.
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077865-1c85d17f-5c47-4681-a0f0-65bbabf2ec78.JPG">
+
+4. Jumper from Dimmer L-IN to Relay COM, and from Relay COM to the snubber (if present). It is recommended to verify that your changes match the updated schematics. This completes the update.
+
+    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235078161-5d425621-2257-48f2-9349-6e662d68b826.JPG">
 
 # Schematics
 
@@ -40,20 +60,3 @@ Independent control allows proper phase recognition, calibration, and tracking.
 
 **Internal Component Housing**
 * [STM32 Internal Comp Housing Schematic - IRD](https://user-images.githubusercontent.com/117388662/235083835-fa2b6721-598c-4fca-9ac7-eb23a2aa596b.png)
-
-# Guide
-1. Disconnect pump source Line that is going to Dimmer L-IN. Tuck away the stock female spade (do not reconnect to the pump) and completely remove the wire that connected it to the Dimmer L-IN in the component housing. 
-
-    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077019-95c1681c-e3e7-40f4-bfc9-07b60f433896.JPG">
-
-2. Find the Line wire going from the coffee switch to the Relay and disconnect it (confirm, but if you followed the schematics exactly it should be connected to Relay COM). 
-
-    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077658-491bb7ed-818c-4cc8-9082-2a1d7aa85e5f.JPG">
-
-3. Move the disconnected coffee switch Line wire to Dimmer L-IN (where you removed the pump wire). You may also want to swap this for a 22 gauge wire for ease of connecting jumpers in the next step.
-
-    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235077865-1c85d17f-5c47-4681-a0f0-65bbabf2ec78.JPG">
-
-4. Jumper from Dimmer L-IN to Relay COM, and from Relay COM to the snubber (if present). It is recommended to verify that your changes match the updated schematics. This completes the update.
-
-    <img width="800" alt="image" src="https://user-images.githubusercontent.com/117388662/235078161-5d425621-2257-48f2-9349-6e662d68b826.JPG">

--- a/docs/guides/lego-independent-relay-dimmer.md
+++ b/docs/guides/lego-independent-relay-dimmer.md
@@ -1,6 +1,8 @@
 This is a guide on how to make the relay (controlling the 3-way valve) and dimmer (controlling the pump) independent on "Lego" (component) builds. 
 Independent control allows proper phase recognition, calibration, and tracking.
 
+!> Required for software releases past **e8933a6** (8-Apr-2023)
+
 > [!Warning]
 > Understanding & utilizing safe electrical practices is critical to your safety and safely completing this project. **Always work with the Gaggia unplugged.** You are performing this project under your own risk and the author of this guide and anyone associated with this project are NOT liable for your actions. 
 

--- a/docs/stm32-upgrade-pack/blackpill.md
+++ b/docs/stm32-upgrade-pack/blackpill.md
@@ -102,16 +102,17 @@ The nano and blackpill/stm32 have different pin setups on their respective board
 
 ## Schematics and Diagrams
 ?>Readers must be aware that you must study both HV and LV diagrams for your specific machine.
+!>Updated with new independent relay and dimmer wiring
 
 **HV Diagrams**
-* [STM32 Comp GCP_Eco HV](https://user-images.githubusercontent.com/53577819/220784834-fb1536e3-81cc-47e8-a243-21f6c3e49a7f.JPG)
-* [STM32 Comp GC HV](https://user-images.githubusercontent.com/53577819/220784848-ab1fe9f1-92cc-40b4-a1c7-7200ab9a2b87.JPG)
-* [STM32 Comp GCP HV](https://user-images.githubusercontent.com/53577819/220784874-583bb885-dce0-4fda-a920-4dc289607213.JPG)
+* [STM32 Comp GC HV - IRD](https://user-images.githubusercontent.com/117388662/235083196-739bb6db-7213-4cac-8293-75cbcc81b5ef.JPG)
+* [STM32 Comp GCP HV - IRD](https://user-images.githubusercontent.com/117388662/235083465-80c8cb69-6442-453d-ac2a-821b7da190be.JPG)
+* [STM32 Comp GCP_Eco HV - IRD](https://user-images.githubusercontent.com/117388662/235083687-5615555c-7295-4172-87b0-cbe3a2414cf9.JPG)
 
 **LV Diagrams**
-* [STM32 Comp GCP_Eco LV](https://user-images.githubusercontent.com/53577819/220784865-b52ffb3f-8380-4225-a539-15d44738d2fe.JPG)
-* [STM32 Comp GC LV](https://user-images.githubusercontent.com/53577819/220784856-c1b5f073-5c0b-470e-b47e-c78eda7099ea.JPG)
-* [STM32 Comp GCP LV](https://user-images.githubusercontent.com/53577819/220784877-279de614-afe9-4bcf-bf27-a6e25edb06bc.JPG)
+* [STM32 Comp GC LV - IRD](https://user-images.githubusercontent.com/117388662/235083350-c73974d9-bef9-4eee-9b8b-436c999ba291.JPG)
+* [STM32 Comp GCP LV - IRD](https://user-images.githubusercontent.com/117388662/235083525-713be71f-dfb9-4c73-9d89-b93d0a19b8ed.JPG)
+* [STM32 Comp GCP_Eco LV - IRD](https://user-images.githubusercontent.com/117388662/235083749-03cd7b0b-acbb-43b4-9705-1a42073605d4.JPG)
 
-**Internal component config**
-* [STM32 Internal Comp Housing Schematic](https://user-images.githubusercontent.com/117388662/230696068-e49df2fa-c3b6-49c2-80ff-629b80780938.png)
+**Internal Component Housing**
+* [STM32 Internal Comp Housing Schematic - IRD](https://user-images.githubusercontent.com/117388662/235083835-fa2b6721-598c-4fca-9ac7-eb23a2aa596b.png)


### PR DESCRIPTION
Added guide, updated schematics on other pages, removed STM32 schematics from nano guide page and replaced it with a link to the STM32 upgrade page for now. Didn't want schematic links living in 3 places.