### PR TITLE
Updated HW scales instructions for new GCP drip tray adapters

### DIFF
--- a/docs/accessories/hw-scales.md
+++ b/docs/accessories/hw-scales.md
@@ -18,7 +18,7 @@ There are two options for HX711 boards - buying two HX711 boards from AliExpress
     * [M3x6mm self-tapping screws for plastic](https://www.aliexpress.com/item/3256802230982244.html)
     * #4-20x1/4" thread rolling screws *(local USA option)*
     * M2.9x6.5mm self-tapping screws for plastic *(local EU option)*
-* **20** (GC) or **36** (GCP) [disc magnets, 5 mm dia. x 2 mm ht.](https://www.aliexpress.com/item/3256803930463196.html)  
+* **20** [disc magnets, 5 mm dia. x 2 mm ht.](https://www.aliexpress.com/item/3256803930463196.html)  
     *Most machine housings are magnetic - subtract 12 magnets if yours is not. The scales will still work but won't be held as securely.*
 * Gap-filling cyanoacrylate (super glue)
 * [**2+** 750 g load cells](https://www.aliexpress.com/item/2251832483911236.html)  
@@ -46,7 +46,7 @@ Print files are available on [Printables](https://www.printables.com/model/28537
     * GC Drip Tray: GC Drip Tray Adapter and 4 Drip Tray Spacers
     * Low-Profile Drip Tray: LP Drip Tray Adapter and 4 Drip Tray Spacers  
         *Note: designed for BaristaGadgets and Shades of Coffee low profile trays*
-    * GCP Drip Tray: GCP Drip Tray Adapter (L and R) and 2 GCP Drip Tray Adapter Clamps
+    * GCP Drip Tray: GCP Drip Tray Adapter (L and R)
     * 3D Print DripTray (no other adapters needed)
 
 # Assembly
@@ -115,16 +115,20 @@ Print files are available on [Printables](https://www.printables.com/model/28537
 
 8. Install magnets in load plates, load cell housings, and drip tray or drip tray adapter parts using the gap-filling cyanoacrylate. Make sure to match the polarity of magnets on the drip tray or drip tray adapter to those on the load plate so that it snaps in place. Holes are sized to only have 0.25 mm extra depth, so if a hole looks like it could fit another magnet put another one in.  
 
-    If your magnet holes are undersized, brush over the edge with a hobby knife to slightly widen the hole, then partially insert the magnet manually. Press down on a flat surface to seat flush.
-
     <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/257019766-5bf71df5-d363-4e2c-8d49-f4f217209356.png">  
 
-    <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/257019800-ee2aac69-5ea5-421d-86a6-8499613f4875.png">
+    <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/267487785-489c145c-5008-4d74-95f0-762e8f978df6.png">
 
+    If your magnet holes are too tight, brush over the edge with a hobby knife to slightly widen the hole, then partially insert the magnet manually. Press down on a flat surface to seat flush.
+
+    If your magnet holes are loose and you want the magnets perfectly flush use a metal ruler with a parchment paper barrier to hold the magnets flush while the glue sets. 
+
+    <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/267475094-bec78ce0-a85b-4c68-b675-d05f1388fabc.png">  
+    
     <details>
-    <summary><b>GCP Drip Tray Adapter tip</b> <i>(Click to expand)</i></summary>
+    <summary><b>Old GCP Drip Tray Adapter tip</b> <i>(Click to expand)</i></summary>
 
-    If you're using the GCP Drip Tray Adapters and Clamps it's easier if you install magnets in the order shown below. Otherwise, the bottom magnets can spin the internal side-facing magnets as you try to install.
+    If you're using the old GCP Drip Tray Adapters and Clamps it's easier if you install magnets in the order shown below. Otherwise, the bottom magnets can spin the internal side-facing magnets as you try to install.
 
     <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/257087212-fe5873c9-405e-4221-abfb-d696fab30ff1.png">
 
@@ -138,13 +142,13 @@ Print files are available on [Printables](https://www.printables.com/model/28537
 
     <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/257088268-c1ab40c7-4c69-4b48-a10c-3b890e8cc97b.png">
 
-    A good way to cleanly cut the profile is to sketch on masking tape, make a pilot hole, use a step drill bit for a 5 mm radius (10 mm diameter), cut with a hacksaw, and then finish with a hobby knife and file.
+    A good way to cleanly cut the profile is to sketch on masking tape, make a pilot hole, use a step drill bit for a 5 mm radius (10 mm diameter), cut with a blade or saw, and then finish with a hobby knife and file.
 
     <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/257088426-229b8358-d270-4efa-bc71-25f75c4685e1.png">
 
-    Slide the drip tray adapters (with clamps installed) onto the drip tray side fins with the “F” side facing the front of the tray. Make sure the adapters are fully seated on the underside of the tray's top surface.
+    Slide the drip tray adapters onto the drip tray side fins. The adapters are labeled F (front) and L (left) or R (right), left/right orientation as if facing the espresso machine. Make sure the adapters are fully seated on the underside of the tray's top surface.
 
-    <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/257088485-a41ab283-63bf-4106-9e10-a985c482aa41.png">
+    <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/267475732-14dbea6c-ff72-45ff-959c-9a5ef89ce215.png">
     <!-- tab:GC/LP Drip Tray Adapter -->
     Fully insert the drip tray spacers into the Gaggia Classic or Low Profile drip tray adapter with the flat surface down. If the fit is not snug use a drop of cyanoacrylate to hold each spacer in place. 
 

--- a/docs/accessories/hw-scales.md
+++ b/docs/accessories/hw-scales.md
@@ -19,7 +19,7 @@ There are two options for HX711 boards - buying two HX711 boards from AliExpress
     * #4-20x1/4" thread rolling screws *(local USA option)*
     * M2.9x6.5mm self-tapping screws for plastic *(local EU option)*
 * **20** [disc magnets, 5 mm dia. x 2 mm ht.](https://www.aliexpress.com/item/3256803930463196.html)  
-    *Most machine housings are magnetic - subtract 12 magnets if yours is not. The scales will still work but won't be held as securely.*
+    *Most machine housings are magnetic - you only need 12 if yours is not. The scales will still work but won't be held as securely.*
 * Gap-filling cyanoacrylate (super glue)
 * [**2+** 750 g load cells](https://www.aliexpress.com/item/2251832483911236.html)  
     *Buying 3-4 load cells is recommended as QC isn't great and they may need modifications that can result in damage if done improperly*

--- a/docs/accessories/hw-scales.md
+++ b/docs/accessories/hw-scales.md
@@ -113,7 +113,7 @@ Print files are available on [Printables](https://www.printables.com/model/28537
 
     At this point you can attach the center housing cover (slides on from the front) and screw it down with the 2 thread-rolling/self-tapping screws.
 
-8. Install magnets in load plates, load cell housings, and drip tray or drip tray adapter parts using the gap-filling cyanoacrylate. Make sure to match the polarity of magnets on the drip tray or drip tray adapter to those on the load plate so that it snaps in place. Holes are sized to only have 0.25 mm extra depth, so if a hole looks like it could fit another magnet put another one in.  
+8. Install magnets in load plates, load cell housings, and drip tray or drip tray adapter parts using the gap-filling cyanoacrylate. It's easiest to put two small drops of the glue on the magnet pocket wall, below the surface. Make sure to match the polarity of magnets on the drip tray or drip tray adapter to those on the load plate so that it snaps in place. Holes are sized to only have 0.25 mm extra depth, but most magnets come in slightly undersized to varying degrees.  
 
     <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/257019766-5bf71df5-d363-4e2c-8d49-f4f217209356.png">  
 
@@ -121,7 +121,7 @@ Print files are available on [Printables](https://www.printables.com/model/28537
 
     If your magnet holes are too tight, brush over the edge with a hobby knife to slightly widen the hole, then partially insert the magnet manually. Press down on a flat surface to seat flush.
 
-    If your magnet holes are loose and you want the magnets perfectly flush use a metal ruler with a parchment paper barrier to hold the magnets flush while the glue sets. 
+    If your magnet holes are loose and you want the magnets perfectly flush use a metal ruler or other magnetic surface with a parchment paper barrier to hold the magnets flush while the glue sets. 
 
     <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/267475094-bec78ce0-a85b-4c68-b675-d05f1388fabc.png">  
     

--- a/docs/guides-stm32/3pln-custom-wiring.md
+++ b/docs/guides-stm32/3pln-custom-wiring.md
@@ -40,3 +40,96 @@
 * [3PLN 120v, GC-specific](https://user-images.githubusercontent.com/53577819/220784232-1b254cd4-d3d7-4fe9-97e5-283fa1fb2659.png)
 * [3PLN 120v](https://user-images.githubusercontent.com/53577819/220784237-e2b841e0-4754-4657-98bd-6adb96255aa1.png)
 * [3PLN 240v](https://user-images.githubusercontent.com/53577819/220784234-0b370f5b-fd5e-4d0d-9b9d-109ff25d2cbf.png)
+
+# Hardware Install Notes
+
+## Thermocouple
+
+Unscrew the brew thermostat, transfer or add thermal paste, then ***Gently** screw in the thermocouple finger-tight (**do not over-tighten**). This can be done in-place, but it's easier to remove the boiler (4 SHCS up from below the sheet metal), steam knob, and steam wand so that the boiler can be tipped up a bit for easier access. You'll want to have the thermocouple wire free to rotate during the install. 
+
+>[!Tip]
+>Depending on your machine type and location of your Gaggiuino control system it may be easier to run the thermocouple wire to the front of the machine and around the boiler to the back instead of going back behind the pump area. Pick the path with the fewest AC wires in the area.
+
+>[!Note]
+>There should already be high-temp thermal paste in place. If there is not, or if the paste is dried out, replace with a paste that has at least a 180°C working temperature. 
+><details>
+><summary><b>Thermal Paste Options</b> <i>(Click to expand)</i></summary>
+>
+>* Thermal Grizzly Kryonaut (350°C max)  
+>* Noctua NT-H2 (200°C max)  
+>* SYY-157 (200°C max)  
+>* GELID GC-Extreme (180°C max)
+></details>
+
+## SSR
+
+Mount the SSR to the back wall of the machine using an M4 (or 8-32) screw, washer, and nut. Make sure the SSR has space above it for the funnel piece and its screw while not touching the pump or pump housing.
+
+## Pressure Transducer
+
+The pressure transducer comes with a base O-ring, however, the threaded length of the fittings vary and many aren't long enough to seal against the base. Insert the small O-ring into the fitting, adjust flush, then screw on the transducer until it seals on an O-ring.
+
+![Transducer and fittings](https://user-images.githubusercontent.com/117388662/239452187-429dafd7-6844-4256-ae76-b9982dcce86c.png ':size=250')
+![Transducer and fittings](https://user-images.githubusercontent.com/117388662/246572048-75f314cb-6585-4351-8c5e-085362841301.png ':size=250')
+
+Cut the tubing in between the pump and boiler, nearer to the boiler but high enough the T is mostly vertical, not horizontal. Attach the appropriate T fitting for your machine. 
+
+> [!Tip]
+> Make sure the tubing is fully engaged on the fittings. It can be helpful to use a grip aid such as silicone tape or a rubber glove to grip the tubing and push it in. For barbed fittings you may even need to use some water-based lubricant to get it all the way on.
+
+Cut a 200-250 mm length of your tubing from the BOM and attach it to the pressure transducer fitting. You'll need to fill that length of tubing with water so there are no air bubbles. There are 2 options:
+
+<details>
+<summary><b>Hand fill</b> <i>(Click to expand)</i></summary>
+
+Surface tension can make hand filling the tube difficult if you don't use a simple trick: insert a small wire down the center of the tubing and inject water with a syringe. The wire allows the water to flow down and the air to vent up because it doesn't let surface tension seal the tube.
+
+![Filling the transducer tubing](https://user-images.githubusercontent.com/117388662/239455051-c8fe0d0a-270e-4685-9478-d751eb746d49.png ':size=250')
+</details>
+
+<details>
+<summary><b>Machine fill</b> <i>(Click to expand)</i></summary>
+
+Plug the tube into the T fitting. After the screen has been connected and the remainder of the install completed, go to the Brew menu, select the Manual tab, set flow to 1 ml/s and run for ~2 minutes (with open group head) to gently fill the line.
+
+![Filling the transducer tubing](https://user-images.githubusercontent.com/117388662/239618595-844609d1-7b59-456e-afba-2d2b1bf73374.png ':size=250')
+
+</details>
+
+Arrange the connected pressure transducer so that it is at the base of the machine, lower than the T fitting. Ignore wiring in the images as they're from a machine following the stock wiring integration. 
+
+<!-- tabs:start -->
+<!-- tab:Gaggia Classic -->
+![pressure transducer placement](https://user-images.githubusercontent.com/117388662/239457706-7ee5d101-d209-41b4-a3d3-ce159e98032f.png ':size=500')
+<!-- tab:Gaggia Classic Pro -->
+![pressure transducer placement](https://user-images.githubusercontent.com/117388662/246573952-ca092066-d107-46e6-85f1-e2a7b19865e0.png ':size=500')
+<!-- tabs:end -->
+
+> [!Tip]
+> While some sensors/setups seem to have no issues with the pump vibration, others are affected by vibration and even the sensor coming in contact with the housing. In those cases it can be beneficial to wrap the sensor in foam.  
+![Foam-wrapped sensor](https://user-images.githubusercontent.com/117388662/239457402-b58dfe55-6572-45b7-8960-2a4d1f9d5753.png ':size=250')
+
+## Internal Finishing Touches
+
+Remove the pins from the screen connector, add a length of heat shrink tubing around the cable bundle so the sharp vent doesn't cut through the soft silicone wire jacket (don't shrink it), and pass the screen wires and ST-Link wires through the back vents. Mount the ST-Link with some double-sided tape.
+
+![Wire pass-through](https://user-images.githubusercontent.com/117388662/239461641-e4f1d5f0-e83c-458c-94ca-61b25a6c7fa0.png ':size=250')
+
+Make sure HV AC wiring and LV DC wiring/sensors are separated. Check that nothing (other than silicone-jacketed wires rated to 200C) can touch the boiler or steam wand. Zip-tie the wire bundle as needed. 
+
+When you're happy with everything, put the cover back on (don't forget to connect the ground wire).
+
+## Screen
+
+There should be extra wire length so the screen can remain connected while the cover is removed. If that is not the case, solder wire extensions. Snake the screen wires through the housing components and replace the pins in the connector. Make sure the wire order matches what you successfully tested in the bench test. I also like to put the nuts in the screen housing cover, use screws to draw them tight, and put a drop of super-glue on the nuts (**not the screws**) to hold them to the housing. When it's dry remove the screws.
+
+![Screen wiring](https://user-images.githubusercontent.com/117388662/239463397-25c3e82c-07e3-4b10-b056-59cbf8d36efc.png ':size=500')
+
+Put the screen housing together, push the spare screen wire (and heat shrink tubing) back through the vent hole and you're ready for espresso! 
+
+<!-- tabs:start -->
+<!-- tab:Gaggia Classic -->
+![Finished!](https://user-images.githubusercontent.com/117388662/239463949-0e90b52f-a5fa-4aed-8ea7-9047154cc213.png ':size=500')
+<!-- tab:Gaggia Classic Pro -->
+![Finished!](https://user-images.githubusercontent.com/117388662/246686394-b0ab3256-57cb-4869-b2dd-51c7778dfa68.png ':size=500')
+<!-- tabs:end -->

--- a/docs/guides-stm32/3pln-stock-wiring-integration.md
+++ b/docs/guides-stm32/3pln-stock-wiring-integration.md
@@ -151,7 +151,7 @@ The 3-way solenoid valve, Pump, and Neutral connections are all integrated into 
 
 ## SSR
 
-Mount the SSR to the back wall of the machine using an M4 screw, washer, and nut. Remove the wires from the steam thermostat (Sa, Sb) and connect to the AC ports on the SSR (order doesn't matter). To ensure a good connection, loop the bare wire around the clamping screw under the clamping plate, or crimp wire to forked spade connectors and clamp those. Remove disconnected thermostat if desired.
+Mount the SSR to the back wall of the machine using an M4 (or 8-32) screw, washer, and nut. Remove the wires from the steam thermostat (Sa, Sb) and connect to the AC ports on the SSR (order doesn't matter). To ensure a good connection, loop the bare wire around the clamping screw under the clamping plate, or crimp wire to forked spade connectors and clamp those. Remove disconnected thermostat if desired.
 
 <!-- tabs:start -->
 <!-- tab:Gaggia Classic -->
@@ -238,7 +238,7 @@ Remove the pins from the screen connector, add a length of heat shrink tubing ar
 
 ![Wire pass-through](https://user-images.githubusercontent.com/117388662/239461641-e4f1d5f0-e83c-458c-94ca-61b25a6c7fa0.png ':size=250')
 
-Make sure HV AC wiring and LV DC wiring/sensors are separated. Zip-tie wire bundle, ensuring disconnected wires and connectors are constrained so they cannot make accidental contact. Here are examples with a component build enclosure:
+Make sure HV AC wiring and LV DC wiring/sensors are separated. Check that nothing (other than silicone-jacketed wires rated to 200C) can touch the boiler or steam wand. Zip-tie the wire bundle as needed, ensuring disconnected wires and connectors are constrained so they cannot make accidental contact. Here are examples with a component build enclosure:
 
 <!-- tabs:start -->
 <!-- tab:Gaggia Classic -->

--- a/docs/guides-stm32/lego-component-build-guide.md
+++ b/docs/guides-stm32/lego-component-build-guide.md
@@ -236,7 +236,10 @@ Wait for the Nextion to show the "Update Successed! (sic)" message, turn off pow
 
 # Component test
 
-Connect the thermocouple to the terminals and power on the system once again. If all is successful you should:
+>[!Tip]
+>The system will not initialize if the ToFnLED board was enabled in the software but isn't plugged in
+
+Make sure the Blackpill, thermocouple, pressure transducer, screen, SSR, switch wires, and ToFnLED if defined are connected and power on the system once again. If all is successful you should:
 - see a build number during boot (good Blackpill-Nextion communication)
 - hear the relay click for boiler fill
 - see a temperature reading on the screen that changes when heat is applied to the thermocouple

--- a/docs/pcb/singleboard.md
+++ b/docs/pcb/singleboard.md
@@ -32,7 +32,7 @@ Wait for the Nextion to show the "Update Successed! (sic)" message, turn off pow
 # Pre-install test
 
 >[!Tip]
->The system will not boot if the ToFnLED board was enabled in the software but isn't plugged in
+>The system will not initialize if the ToFnLED board was enabled in the software but isn't plugged in
 
 Connect the system components (Blackpill, thermocouple, pressure transducer, screen, SSR, switch wires, ToFnLED if defined) to the PCB and power on the system through the USB-C port on the blackpill. If all is successful you should:
 - see a build number during boot (good Blackpill-Nextion communication)

--- a/docs/pcb/singleboard.md
+++ b/docs/pcb/singleboard.md
@@ -31,7 +31,10 @@ Wait for the Nextion to show the "Update Successed! (sic)" message, turn off pow
 
 # Pre-install test
 
-Connect the thermocouple to the terminals and power on the system once again. If all is successful you should:
+>[!Tip]
+>The system will not boot if the ToFnLED board was enabled in the software but isn't plugged in
+
+Connect the system components (Blackpill, thermocouple, pressure transducer, screen, SSR, switch wires, ToFnLED if defined) to the PCB and power on the system through the USB-C port on the blackpill. If all is successful you should:
 - see a build number during boot (good Blackpill-Nextion communication)
 - see a "filling boiler" message a few seconds after boot
 - see a temperature reading on the screen that changes when heat is applied to the thermocouple


### PR DESCRIPTION
New drip tray adapter pics, instructions, and BOM edit
![image](https://github.com/GAGGIUINO/gaggiuino.github.io/assets/117388662/94710d49-bb8f-4d33-a240-93f648d19b3b)
![image](https://github.com/GAGGIUINO/gaggiuino.github.io/assets/117388662/3aa051b0-7e1a-4008-bc8e-f6e93f30a3d3)

Fixed PCB pre-install test connection items, add ToFnLED note, updated wording on comp build test as well to parallel it
![image](https://github.com/GAGGIUINO/gaggiuino.github.io/assets/117388662/ffc06a01-a55e-4e8c-9646-fe7d2147d93d)

Added Hardware Install Notes section to the 3PLN Custom Wiring instructions
Content is essentially the same as for the 3PLN Stock Wiring Integration, just reworded slightly for the custom wiring
![image](https://github.com/GAGGIUINO/gaggiuino.github.io/assets/117388662/d0eeefa2-dab0-41a0-b814-42cda955ce4b)
