### PR TITLE
Add links to alternate sellers for Arduino Nano expansion board

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -167,6 +167,7 @@ Name                                      | Voltage   | Model Years | Model ID  
 * [STM32F411CEU6 | F411 25M HSE](https://www.aliexpress.com/item/1005001456186625.html) **MAKE SURE THE PROPER BOARD IS SELECTED**
 * [ST-Link-STM32](https://www.aliexpress.com/item/1005005303809188.html)
 * [Arduino Nano expansion board](https://www.aliexpress.com/item/32325724150.html) **GET THE GREEN ONE**
+  * Alternative sellers [A](https://www.aliexpress.us/item/3256806437782547.html) or [B](https://www.aliexpress.us/item/3256806096706809.html)
 * [ADS1115](https://www.aliexpress.com/item/32869421559.html)
 * [5V RELAY](https://www.aliexpress.com/item/3256803997020234.html) 
 * [2.4" Nextion LCD](https://www.aliexpress.com/item/3256803271061345.html) **+ MicroSD card (Class 10 HC 8GB to 32GB)**

--- a/docs/README.md
+++ b/docs/README.md
@@ -167,7 +167,7 @@ Name                                      | Voltage   | Model Years | Model ID  
 * [STM32F411CEU6 | F411 25M HSE](https://www.aliexpress.com/item/1005001456186625.html) **MAKE SURE THE PROPER BOARD IS SELECTED**
 * [ST-Link-STM32](https://www.aliexpress.com/item/1005005303809188.html)
 * [Arduino Nano expansion board](https://www.aliexpress.com/item/32325724150.html) **GET THE GREEN ONE**
-  * Alternative sellers [A](https://www.aliexpress.us/item/3256806437782547.html) or [B](https://www.aliexpress.us/item/3256806096706809.html)
+  * [Alternative seller](https://www.aliexpress.com/item/3256806096706809.html)
 * [ADS1115](https://www.aliexpress.com/item/32869421559.html)
 * [5V RELAY](https://www.aliexpress.com/item/3256803997020234.html) 
 * [2.4" Nextion LCD](https://www.aliexpress.com/item/3256803271061345.html) **+ MicroSD card (Class 10 HC 8GB to 32GB)**


### PR DESCRIPTION
The seller at the existing link for the [Arduino Nano expansion board](https://www.aliexpress.com/item/32325724150.html) has been out of stock for the past 3 months at least. Several users have commented in the Discord since March 2024 (at least), asking about substitutes, due to poor availability.

I searched the Discord and found two other sellers that appear to sell the same product, both of which are in stock right now. I suggest that the README links to one or both of these alternatives, in addition to the existing link.

I hope this helps the next person that comes along and has difficulty locating this board.