### PR TITLE
Add Gen 3 notes for hw scales and tofnled, update community media

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -182,7 +182,7 @@ Name                                      | Voltage   | Model Years | Model ID  
 * [Flat gasket/o-ring | 1|4 inch pipe (11 x 6 mm), 3 mm thick](https://www.aliexpress.com/item/2255799841120591.html)
 
 <!-- tab:STM32 LEGO -->
-* [STM32F411CEU6 | F411 25M HSE](https://www.aliexpress.com/item/1005001456186625.html) **MAKE SURE THE PROPER BOARD IS SELECTED**
+* [STM32U585CIU6](https://www.aliexpress.com/item/3256807730943902.html)
 * [ST-Link-STM32](https://www.aliexpress.com/item/1005005303809188.html)
 * [Arduino Nano expansion board](https://www.aliexpress.com/item/32325724150.html) **GET THE GREEN ONE**
 * [ADS1115](https://www.aliexpress.com/item/32869421559.html)
@@ -241,7 +241,7 @@ Name                                      | Voltage   | Model Years | Model ID  
 
 <!-- tabs:start -->
 <!-- tab:Gen 3 -->
-* 4.3" ESP32-S3 Screen **- must be activated by [PeakCoffee](https://www.peakcoffee.cc/product/4-3-iot-gaggiuino-lcd/) or [DIY-EFI](https://diy-efi.co.uk/product/gaggiuino_esp32_43_screen)**
+* 4.3" ESP32-S3 Screen & cable - **must be activated by [PeakCoffee](https://www.peakcoffee.cc/product/4-3-iot-gaggiuino-lcd/) or [DIY-EFI](https://diy-efi.co.uk/product/gaggiuino_esp32_43_screen)**
 
 <!-- tab:Gen 2 -->
 * [2.4" Nextion LCD](https://www.aliexpress.com/item/3256803271061345.html) **+ MicroSD card (Class 10 HC 2GB to 32GB)**

--- a/docs/README.md
+++ b/docs/README.md
@@ -108,7 +108,7 @@ Name                                      | Voltage   | Model Years | Model ID  
 
 2. **Determine your build path.** 
 
-  Decide if you're going to order a [PCB](guides-stm32/pcb-guide.md) or build a [component (Lego)](guides-stm32/lego-component-build-guide.md) control system. PCBv4 is recommended for new Gen 3 builds, while PCBv3.1 is recommended for Gen 2 builds. The component build is slightly more flexible for experimentation and less picky about thermocouple grounding, however, it adds significant effort and makes reliability dependent on the maker's skill. 
+  Decide if you're going to order a [PCB](guides-stm32/pcb-guide.md) or build a [component (Lego)](guides-stm32/lego-component-build-guide.md) control system. PCBv4 is recommended for new Gen 3 builds, while PCBv3.1 is recommended for Gen 2 builds (see [Features](#features) and [Announcements](announcements/) to compare Gen 2 and Gen 3). The component build is slightly more flexible for experimentation and less picky about thermocouple grounding, however, it adds significant effort and makes reliability dependent on the maker's skill. 
 
   Decide how to integrate the control system with your espresso machine. It can either be [integrated into the stock wiring](guides-stm32/3pln-stock-wiring-integration.md) with a few jumpers (less wiring, but sometimes more confusing) or the stock wiring can be replaced with a [custom wiring harness](guides-stm32/3pln-custom-wiring.md) (more work, but results in a clean, straightforward install). It is recommended that you check the notes in the [Compatibility Table](#compatibility) for your machine and and read through the instructions before deciding.
 
@@ -168,7 +168,7 @@ Name                                      | Voltage   | Model Years | Model ID  
 <!-- tab:STM32 PCB -->
 * **PCB (Pick one)**
   * **PCBv4 (recommended, available at approved suppliers)**
-  * [PCBv3 *(custom order)*](https://github.com/banoz/CoffeeHat/tree/main/Hardware/GaggiaBoard_V3) and [BlackPill | F411 25M HSE *(make sure the proper version is selected)*](https://www.aliexpress.com/item/1005001456186625.html)
+  * [PCBv3 *(custom order)*](https://github.com/banoz/CoffeeHat/tree/main/Hardware/GaggiaBoard_V3) and [STM32U585CIU6 *(for Gen 3)*](https://www.aliexpress.com/item/3256807730943902.html) or [BlackPill | F411 25M HSE *(for Gen 2)*](https://www.aliexpress.com/item/1005001456186625.html)
 * [ST-Link-STM32](https://www.aliexpress.com/item/1005005303809188.html)
 * [Ungrounded Thermocouple Sensor | K-type, M4, 0.5 m long](https://www.aliexpress.com/item/3256805310471537.html)
 * [SSR-40DA Relay](https://www.aliexpress.com/item/3256806134543825.html)
@@ -182,7 +182,7 @@ Name                                      | Voltage   | Model Years | Model ID  
 * [Flat gasket/o-ring | 1|4 inch pipe (11 x 6 mm), 3 mm thick](https://www.aliexpress.com/item/2255799841120591.html)
 
 <!-- tab:STM32 LEGO -->
-* [STM32U585CIU6](https://www.aliexpress.com/item/3256807730943902.html)
+* [STM32U585CIU6 *(for Gen 3)*](https://www.aliexpress.com/item/3256807730943902.html) or [BlackPill | F411 25M HSE *(for Gen 2)*](https://www.aliexpress.com/item/1005001456186625.html)
 * [ST-Link-STM32](https://www.aliexpress.com/item/1005005303809188.html)
 * [Arduino Nano expansion board](https://www.aliexpress.com/item/32325724150.html) **GET THE GREEN ONE**
 * [ADS1115](https://www.aliexpress.com/item/32869421559.html)

--- a/docs/accessories/hw-scales.md
+++ b/docs/accessories/hw-scales.md
@@ -287,20 +287,19 @@ Print files are available on [Printables](https://www.printables.com/model/28537
 
     <img width="500" alt="image" src="https://github.com/user-attachments/assets/c120b6d2-3a97-42e5-9bd1-bd1d96d96f4f">
 
-2. One at a time, unscrew the load plates. You'll use the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration load (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range. 
+2. Unscrew both load plates, keeping track of which screws are more magnetic. You'll use the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration load (in this case a 318.5 g tamper). Weigh the calibration load plate and load **together** on a scale to get the calibration weight - ideal calibration weight is in the 200-400g range. 
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/275450371-a6c50ca3-95ef-46df-9e21-6bb3e654535e.png">
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/257110291-ae8bf438-a692-4b89-b511-8ef8073f1065.png">
 
     To calibrate:
-    - Weigh the calibration load plate and load together to get the calibration weight
-    - Tare with load cells empty
-    - Place calibration load plate and load
+    - Tare (with load cells empty)
+    - Place the calibration load plate and load on one load cell
     - Compare reported weight to the total calibration weight
     - Remove the calibration load plate and load
-    - Type (or use the +/- buttons) to adjust the scale factor, then wait for the "Updated running settings" message (it will auto-tare)
-    - Repeat on each side until the weight output in grams matches the calibration weight. One scale factor will likely be negative to make the output in grams positive.
+    - Type (or use the +/- buttons) to adjust the scale factor, then wait for the "Updated running settings" message (scales will auto-tare)
+    - Repeat on the same load cell until the weight value (grams) matches the calibration weight, then switch to the other load cell. One load cell calibration factor will likely be negative to make the weight value positive.
     - Click Save
 
 <!-- tab:Gen 2 -->
@@ -340,13 +339,13 @@ Use the appropriate scales-calibration task to upload to the STM32 and copy scal
 
 <!-- tabs:end -->
 
-2. Unscrew the load plates and replace with the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration load (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range.
+2. Unscrew the load plates and replace with the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration load (in this case a 318.5 g tamper). Weigh the calibration load plate and load **together** on a scale to get the calibration weight - ideal calibration weight is in the 200-400g range. 
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/275450371-a6c50ca3-95ef-46df-9e21-6bb3e654535e.png">
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/257110291-ae8bf438-a692-4b89-b511-8ef8073f1065.png">
 
-    To calibrate, use the adjustment value and +/- buttons to adjust the scale factors until the weight output in grams matches the real weight (load + calibration load plate). One scale factor will likely be negative to make the output in grams positive. Take a pic or copy down the scale factors.
+    To calibrate, use the adjustment value and +/- buttons to adjust the scale factors until the weight output in grams matches the calibration weight (load + calibration load plate). One scale factor will likely be negative to make the output in grams positive. Take a pic or copy down the scale factors.
 
 3. Once calibrated, flash the regular build back onto the screen and STM32. Copy the scale factors into the LC1 and LC2 Factors and click Save. After saving, reboot the machine to load the new LC factors.
 

--- a/docs/accessories/hw-scales.md
+++ b/docs/accessories/hw-scales.md
@@ -296,11 +296,14 @@ Print files are available on [Printables](https://www.printables.com/model/28537
     To calibrate:
     - Tare (with load cells empty)
     - Place the calibration load plate and load on one load cell
-    - Compare reported weight to the total calibration weight
+    - Compare the reported weight value to the total calibration weight
     - Remove the calibration load plate and load
-    - Type (or use the +/- buttons) to adjust the scale factor, then wait for the "Updated running settings" message (scales will auto-tare)
-    - Repeat on the same load cell until the weight value (grams) matches the calibration weight, then switch to the other load cell. One load cell calibration factor will likely be negative to make the weight value positive.
-    - Click Save
+    - Type (or use the +/- buttons) to adjust the load cell calibration factor, then wait for the "Updated running settings" message (scales will auto-tare)
+    - Repeat on the same load cell until the weight value matches the calibration weight, then switch to the other load cell. 
+    - Click Save  
+
+> [!NOTE|style:callout|label:Weight must be positive|iconVisibility:visible]
+> Make sure the **weight value (grams) is positive** - due to the mirrored load cell orientation one load cell calibration factor will likely be negative.  
 
 <!-- tab:Gen 2 -->
 

--- a/docs/accessories/hw-scales.md
+++ b/docs/accessories/hw-scales.md
@@ -9,6 +9,10 @@ If extreme experimentation with beans, grinds, or shot profiles is your fetish i
 
 # Bill of Materials
 
+> [!TIP|style:callout|label:Sourcing|iconVisibility:visible]
+> PCBs, kits, and 3D-printed parts may be ordered from the **Approved Official Suppliers** in the sidebar.  
+> Alternatively, components can be ordered individually and parts can be printed from the design files. 
+
 ## Components
 
 There are two options for HX711 boards - buying two HX711 boards from AliExpress or using the dualScaleBoard (sometimes called the SingleHX711Board).
@@ -273,6 +277,32 @@ Print files are available on [Printables](https://www.printables.com/model/28537
 
 # Flashing/Calibration
 
+
+<!-- tabs:start -->
+<!-- tab:Gen 3 -->
+
+1. Enter calibration menu
+
+    Go to [gaggiuino.local](http://gaggiuino.local/), then navigate to **SETTINGS**, **SCALES**, and then click **CALIBRATE**
+
+    <img width="500" alt="image" src="https://github.com/user-attachments/assets/c120b6d2-3a97-42e5-9bd1-bd1d96d96f4f">
+
+2. One at a time, unscrew the load plates. You'll use the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration weight (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range.
+
+    <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/275450371-a6c50ca3-95ef-46df-9e21-6bb3e654535e.png">
+
+    <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/257110291-ae8bf438-a692-4b89-b511-8ef8073f1065.png">
+
+    To calibrate:
+    - Tare with load cells empty
+    - add calibration plate and weight, then see what the value is
+    - remove the weight
+    - type in (or use the +/- buttons) to adjust the scale factor, then wait for the "Updated running settings" message (it will auto-tare)
+    - repeat until the weight output in grams matches the real weight. One scale factor will likely be negative to make the output in grams positive.
+    - Click Save
+
+<!-- tab:Gen 2 -->
+
 1. Build and flash the scales calibration task
 
 <!-- tabs:start -->
@@ -305,6 +335,7 @@ build_flags =
 Use the appropriate scales-calibration task to upload to the STM32 and copy scales-calibrate TFT onto a microSD card to flash the Nextion. You should see this show up on the screen (with numbers). If there are no numbers your screen-STM32 connection is likely bad or an incorrect task was flashed.
 
 <img width="300" alt="image" src="https://user-images.githubusercontent.com/117388662/257109779-2888a68b-7131-4243-824b-c43cc3ac4b8c.png">
+
 <!-- tabs:end -->
 
 2. Unscrew the load plates and replace with the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration weight (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range.
@@ -318,6 +349,8 @@ Use the appropriate scales-calibration task to upload to the STM32 and copy scal
 3. Once calibrated, flash the regular build back onto the screen and STM32. Copy the scale factors into the LC1 and LC2 Factors and click Save. After saving, reboot the machine to load the new LC factors.
 
     <img width="300" alt="image" src="https://user-images.githubusercontent.com/117388662/257110664-fd0f6aa1-aefe-4a6d-b167-12183f9d1b87.png">
+
+<!-- tabs:end -->
 
 4. Add the drip tray / drip tray adapter. Congrats, your machine has a scale!
 

--- a/docs/accessories/hw-scales.md
+++ b/docs/accessories/hw-scales.md
@@ -287,18 +287,20 @@ Print files are available on [Printables](https://www.printables.com/model/28537
 
     <img width="500" alt="image" src="https://github.com/user-attachments/assets/c120b6d2-3a97-42e5-9bd1-bd1d96d96f4f">
 
-2. One at a time, unscrew the load plates. You'll use the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration weight (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range.
+2. One at a time, unscrew the load plates. You'll use the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration load (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range. 
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/275450371-a6c50ca3-95ef-46df-9e21-6bb3e654535e.png">
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/257110291-ae8bf438-a692-4b89-b511-8ef8073f1065.png">
 
     To calibrate:
+    - Weigh the calibration load plate and load together to get the calibration weight
     - Tare with load cells empty
-    - add calibration plate and weight, then see what the value is
-    - remove the weight
-    - type in (or use the +/- buttons) to adjust the scale factor, then wait for the "Updated running settings" message (it will auto-tare)
-    - repeat until the weight output in grams matches the real weight. One scale factor will likely be negative to make the output in grams positive.
+    - Place calibration load plate and load
+    - Compare reported weight to the total calibration weight
+    - Remove the calibration load plate and load
+    - Type (or use the +/- buttons) to adjust the scale factor, then wait for the "Updated running settings" message (it will auto-tare)
+    - Repeat on each side until the weight output in grams matches the calibration weight. One scale factor will likely be negative to make the output in grams positive.
     - Click Save
 
 <!-- tab:Gen 2 -->
@@ -338,13 +340,13 @@ Use the appropriate scales-calibration task to upload to the STM32 and copy scal
 
 <!-- tabs:end -->
 
-2. Unscrew the load plates and replace with the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration weight (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range.
+2. Unscrew the load plates and replace with the calibration load plate to space the load away from the load cell housing (otherwise the housing will take some of the load). I prefer to detach the load cell housing from the center housing as shown to get more room to fit the calibration load (in this case a 318.5 g tamper). Ideal calibration weight is in the 200-400g range.
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/275450371-a6c50ca3-95ef-46df-9e21-6bb3e654535e.png">
 
     <img height="300" alt="image" src="https://user-images.githubusercontent.com/117388662/257110291-ae8bf438-a692-4b89-b511-8ef8073f1065.png">
 
-    To calibrate, use the adjustment value and +/- buttons to adjust the scale factors until the weight output in grams matches the real weight. One scale factor will likely be negative to make the output in grams positive. Take a pic or copy down the scale factors.
+    To calibrate, use the adjustment value and +/- buttons to adjust the scale factors until the weight output in grams matches the real weight (load + calibration load plate). One scale factor will likely be negative to make the output in grams positive. Take a pic or copy down the scale factors.
 
 3. Once calibrated, flash the regular build back onto the screen and STM32. Copy the scale factors into the LC1 and LC2 Factors and click Save. After saving, reboot the machine to load the new LC factors.
 

--- a/docs/accessories/tofnled.md
+++ b/docs/accessories/tofnled.md
@@ -86,6 +86,8 @@ Run the Qwiic cable down through the gap on the right side of the machine sheet 
 
 Flash core (the MCU) with the applicable binary (.bin) file per [MCU Flashing](guides-stm32/mcu-flashing.md).
 
+Select a color and intensity via WebUI or on the screen (certain combinations of colors and themes may reduce control visibility on the screen)
+
 <!-- tab:Gen 2 -->
 Create a file in the project folder called "extra_defines.ini"  
 The exact contents of the file depend on your system build, but it will look something like this (green lines are commented out and inactive). 

--- a/docs/accessories/tofnled.md
+++ b/docs/accessories/tofnled.md
@@ -7,8 +7,11 @@ The Time of Flight and LED (ToFnLED) board provides a sensor for determining tan
 
 ## Bill of Materials
 
-> [!Note] Understanding of the PCB ordering/manufacturing process is needed to order the ToFnLED. For housing compatibility do **not** add the backside connector.  
-Conformal coating the PCB is highly recommended for longevity. This can be done as part of the PCB assembly process or manually post-assembly.
+> [!TIP|style:callout|label:Sourcing|iconVisibility:visible]
+> PCBs, kits, and 3D-printed parts may be ordered from the **Approved Official Suppliers** in the sidebar.  
+> Alternatively, components can be ordered individually and parts can be printed from the design files. Understanding of the PCB ordering/manufacturing process is needed to order the ToFnLED from PCBWay. For housing compatibility do **not** add the backside connector.
+
+> [!Note] Conformal coating the PCB is highly recommended for longevity. This can be done as part of the PCB assembly process or manually post-assembly.
 
 <!-- tabs:start -->
 <!-- tab:PCB -->
@@ -76,9 +79,15 @@ Run the Qwiic cable down through the gap on the right side of the machine sheet 
 
 <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/256464601-0d54fd7a-0f65-495e-8169-83fe9bd14a53.png">
 
-# Extra Defines
+# Software Changes
 
-The ToF and LED elements need to be enabled in the code. To do so, create a file in the project folder called "extra_defines.ini"  
+<!-- tabs:start -->
+<!-- tab:Gen 3 -->
+
+Flash core (the MCU) with the applicable binary (.bin) file per [MCU Flashing](guides-stm32/mcu-flashing.md).
+
+<!-- tab:Gen 2 -->
+Create a file in the project folder called "extra_defines.ini"  
 The exact contents of the file depend on your system build, but it will look something like this (green lines are commented out and inactive). 
 
 <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/256468372-14e57794-6ded-4bc1-a641-921cd4c6ca58.png">
@@ -105,6 +114,7 @@ build_flags =
 <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/274979976-ae9f02ab-8c61-438e-81ea-adfabdff183b.png">
 
 </details>
+<!-- tabs:end -->
 
 >
 # Troubleshooting

--- a/docs/announcements/README.md
+++ b/docs/announcements/README.md
@@ -14,11 +14,11 @@
 
 ## Development Lifecycle
 >
-Gen| Microcontroller (MCU)                  | Screen/UI| Compatible Builds                                                     | Release Date       |Dev Stop | Current Support  | 
-:-:|----------------------------------------|----------|-----------------------------------------------------------------------|--------------------|---------|:----------------:|
-1  |ATmega328<br/> (Arduino Nano)           |Nextion   |**Component (Lego)**<br/>PCBv1<br/>(MainBoard + SubBoard)              | 2021               |June 2022|:x:               |
-2  |STM32F411CEU6                           |Nextion   |Component (Lego)<br/>PCBv2 / PCBv2.1 :warning:<br/>PCBv3 / **PCBv3.1**           | June 2022          |July 2023|:heavy_check_mark:| 
-3  |STM32F411CEU6 (OC)<br/>**STM32U585CIU6**|ESP32-S3<br/>(Embedded & Web)|Component (Lego)<br/>PCBv2 / PCBv2.1 :warning:<br/>PCBv3 / PCBv3.1<br/>**PCBv4**|September 2024|         |:heavy_check_mark:|     
+Gen| Microcontroller (MCU)                  | Screen/UI| Compatible Builds                                                     |Beta    | Release  |Last Commit   | Current Support  | 
+:-:|:---------------------------------------|:--------:|:----------------------------------------------------------------------|:------:|:--------:|:------------:|:----------------:|
+1  |ATmega328<br/> (Arduino Nano)           |Nextion   |**Component (Lego)**<br/>PCBv1<br/>(MainBoard + SubBoard)              |2021    | -        |Sep 2022      |:x:               |
+2  |STM32F411CEU6                           |Nextion   |Component (Lego)<br/>PCBv2 / PCBv2.1 :warning:<br/>PCBv3 / **PCBv3.1** |Jul 2022| May 2023 |Mar 2024      |:heavy_check_mark:| 
+3  |STM32F411CEU6 (OC)<br/>**STM32U585CIU6**|ESP32-S3<br/>(Embedded & Web)|Component (Lego)<br/>PCBv2 / PCBv2.1 :warning:<br/>PCBv3 / PCBv3.1<br/>**PCBv4**|May 2024|Sep 2024|-|:heavy_check_mark:|     
 
 >
 * :warning: - *PCBv2 / PCBv2.1 are compatible but support is minimal.*

--- a/docs/community/community-media.md
+++ b/docs/community/community-media.md
@@ -5,20 +5,31 @@
 
 ## Community Speaks
 
+> [!Note|style:callout|label:Video Note|iconVisibility:visible]
+> Videos are from the Gaggiuino community and showcase some of the capabilities and impressions of the project.  
+> **They should not be referenced for installation techniques, technical data, or seen as feature documentation** as the project is still in active development and video accuracy has not been verified.
+
 <!-- panels:start -->
 <!-- div:left-panel -->
-?> Lance Hedrick review
-<iframe width="560" height="315" src="https://www.youtube.com/embed/V4pTFCGVlmQ" title="GAGGIUINO BUILD LOG" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+?> Gaggiuino Gen 3 | Lance Hedrick
+<iframe width="560" height="315" src="https://www.youtube.com/embed/UaC4IQO2WCk" title="Ultimate Budget Espresso Machine" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <!-- div:right-panel -->
-
-?> Gaggiuino vs Decent | User review
-<iframe width="560" height="315" src="https://www.youtube.com/embed/V4kAgPm1Xfw" title="GAGGIUINO vs Decent" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+?> Gaggiuino Gen 2 | Lance Hedrick
+<iframe width="560" height="315" src="https://www.youtube.com/embed/V4pTFCGVlmQ" title="GAGGIUINO BUILD LOG" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
 
 <!-- panels:end -->
 
-?> Community menber setup
+<!-- panels:start -->
+<!-- div:left-panel -->
+?> Gaggiuino vs Decent | User review
+<iframe width="560" height="315" src="https://www.youtube.com/embed/V4kAgPm1Xfw" title="GAGGIUINO vs Decent" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<!-- div:right-panel -->
+?> Community member setup
 <iframe width="560" height="315" src="https://www.youtube.com/embed/ERGxo8fYc5g" title="YouTube video player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture" allowfullscreen></iframe>
+
+<!-- panels:end -->
 
 <details>
 

--- a/docs/guides-stm32/mcu-flashing.md
+++ b/docs/guides-stm32/mcu-flashing.md
@@ -104,7 +104,7 @@ Make sure **Verify programming** is selected and **Skip flash erase before progr
 
 > [!Warning|style:callout|label:Warning|iconVisibility:visible]
 > * ESP32 systems **must be enabled by official suppliers** to work with Gaggiuino Gen 3.  
-> * Core OTA is compatible with STM32**U585** only (PCBv4 and systems with uPill or WeAct U585 Core Board). Sometimes those PCBs may need to be flashed with STM32CubeProgrammer - this will be stated in the release notes if necessary. 
+> * Core OTA is compatible with STM32**U585** only (PCBv4 and systems with uPill or WeAct U585 Core Board). Sometimes the U585 may need to be flashed with STM32CubeProgrammer - this will be stated in the release notes if necessary. 
 
 1. Identify the file(s) to flash from [Releases](#Releases).  
 

--- a/docs/guides-stm32/mcu-flashing.md
+++ b/docs/guides-stm32/mcu-flashing.md
@@ -104,7 +104,7 @@ Make sure **Verify programming** is selected and **Skip flash erase before progr
 
 > [!Warning|style:callout|label:Warning|iconVisibility:visible]
 > * ESP32 systems **must be enabled by official suppliers** to work with Gaggiuino Gen 3.  
-> * Core OTA is compatible with STM32**U585** (PCBv4 and PCBs with custom uPill) only. Sometimes those PCBs may need to be flashed with STM32CubeProgrammer - this will be stated in the release notes if necessary. 
+> * Core OTA is compatible with STM32**U585** only (PCBv4 and systems with uPill or WeAct U585 Core Board). Sometimes those PCBs may need to be flashed with STM32CubeProgrammer - this will be stated in the release notes if necessary. 
 
 1. Identify the file(s) to flash from [Releases](#Releases).  
 

--- a/docs/guides-stm32/mcu-flashing.md
+++ b/docs/guides-stm32/mcu-flashing.md
@@ -14,7 +14,7 @@ For wired flashing - required for BlackPill-based PCBs (PCBv2, PCBv3) and PCBv3.
 
 Then pull the code as shown in the below video:
 <details>
-<summary>Setup project using PIO (Click to expand)</summary>
+<summary>Setup project using PIO <i>(Click to expand)</i></summary>
 
 [Platform IO](https://user-images.githubusercontent.com/109426580/193900425-15c42d9c-adf4-4073-aa46-34874528bf43.mp4 ':include :type=video controls width=70%')
 </details>
@@ -32,12 +32,20 @@ Make sure to switch to the necessary [release branch](#Releases) once pulled, de
 > __2. Failing to flash the correct binary for your hardware will yield unexpected results.__   
 > __3. Make sure the microcontroller and screen unit are in sync.__  
 
-Released binary (.bin) files can be found on the [Gaggiuino Github Releases](https://github.com/Zer0-bit/gaggiuino/releases) page. Files selection depends on your system hardware.
+Released binary (.bin) files are on the [Gaggiuino Github Release (Latest)](https://github.com/Zer0-bit/gaggiuino/releases/latest) page. Files selection depends on your system hardware.
   * Core (STM32): 1 file, named in format *MCU - Build Type - LED Controller .bin* per hardware (see table below).  
-   _MCU_                                    | *Build Type*                  | *LED Controller*     |  
-   :---------------------------------------:|:-----------------------------:|:--------------------:|  
-   __performance__<br/>*STM32**U585**CIU6*  |**pcb**<br/>*PCBv2 - PCBv4*    |**ncp**<br/>*NCP5623* |  
-   <br/>*STM32**F411**CEU6*                 |**lego**<br/>*Component build* |**pca**<br/>*PCA9632* |  
+    |Title | Name | Hardware |
+    |:--:|:--:|:--|
+    |**MCU**            | performance <br/> -           | STM32**U585**CIU6 (PCBv4, fuPill) <br/> STM32**F411**CEU6 (PCBv3.1, BlackPill)|
+    |**Build Type**     | pcb <br/> lego                | PCBv2 - PCBv4 <br/> Component build |
+    |**LED Controller <sup>[1]</sup>** | pca <br/> ncp  | PCA9632 <br/> NCP5623 |
+    <details>
+    <summary><b>[1] See this for help identifying your LED controller - most are PCA </b><i>(Click to expand)</i></summary>
+
+    <img width="600" alt="image" src="https://user-images.githubusercontent.com/117388662/274979976-ae9f02ab-8c61-438e-81ea-adfabdff183b.png">
+
+    </details>  
+  
   * UI (ESP32)
     * Screen: *ui-embedded.bin* and *ui-web.bin*  
     * Headless: *ui-headless.bin* and *ui-web.bin* 
@@ -132,6 +140,7 @@ The password is the network name with a zero substituted for the "o" and the spa
 
 > [!Note|style:callout|label:Notes|iconVisibility:visible]
 > * Do not power down the system during an update. If an update fails or is cancelled before completion the system will automatically revert to the previous firmware.  
+> * If OTA updates fail while connected to a network: disconnect Gaggiuino from the network and connect your device directly to Gaggiuino AP (step 2).
 > * After a *ui-web.bin* update the browser may need to be refreshed to load new elements (if any). 
 
 <!-- tab:Gen 2 -->


### PR DESCRIPTION
- Add Gen 3 instructions for HW Scales & ToFnLED
- Update Gen 3 BOM for PCBv3 and component build to U585 and clarified language in flashing instructions (OTA works for all U585 regardless of the build type)
- Add Lance's Gen 3 video to the community media page and add a warning because some videos are quite out of date 
- Correct lifecycle table in announcements. Old dates were confusing because the table didn't differentiate beta vs release status